### PR TITLE
Support macOS (via homebrew)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-sudo: required
-
 language: perl
 
-services:
-  - docker
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      services: docker
+    - os: osx
 
-before_install:
-  - ./maint/build-docker
-  - docker ps -a
+before_install: ./maint/travis-ci/before-install
 
 install: true
 
-script:
-  - docker run --rm -it oberth:latest sh -c 'cd /build/curie && perl /build/bin/oberthian test'
+script: ./maint/travis-ci/script

--- a/lib/Oberth/Prototype.pm
+++ b/lib/Oberth/Prototype.pm
@@ -33,6 +33,7 @@ use CLI::Osprey;
 
 use ShellQuote::Any;
 use File::Path qw(make_path);
+use File::Which;
 
 use Oberth::Common::Setup;
 
@@ -40,6 +41,7 @@ use Oberth::Prototype::Config;
 use Oberth::Prototype::Repo;
 
 use Oberth::Prototype::System::Debian;
+use Oberth::Prototype::System::MacOSHomebrew;
 
 has repo_url_to_repo => (
 	is => 'ro',
@@ -49,9 +51,15 @@ has repo_url_to_repo => (
 has config => (
 	is => 'ro',
 	default => sub {
+		my $system;
+		if(  $^O eq 'darwin' && which('brew') ) {
+			$system = Oberth::Prototype::System::MacOSHomebrew->new;
+		} else {
+			$system = Oberth::Prototype::System::Debian->new;
+		}
 		Oberth::Prototype::Config->new(
 			build_tools_dir => BUILD_TOOLS_DIR,
-			platform => Oberth::Prototype::System::Debian->new,
+			platform => $system,
 		);
 	},
 );

--- a/lib/Oberth/Prototype/Command/Bootstrap.pm
+++ b/lib/Oberth/Prototype/Command/Bootstrap.pm
@@ -65,6 +65,7 @@ sub run_setup {
 	$self->install_self_contained_cpm unless $self->has_cpm;
 
 	$self->_cpm(
+		'--resolver', '02packages,http://cpan.metacpan.org',
 		qw(App::cpanminus),
 	) unless $self->has_cpanm;
 

--- a/lib/Oberth/Prototype/System/MacOSHomebrew.pm
+++ b/lib/Oberth/Prototype/System/MacOSHomebrew.pm
@@ -1,0 +1,70 @@
+use Modern::Perl;
+package Oberth::Prototype::System::MacOSHomebrew;
+# ABSTRACT: macOS with homebrew
+
+use Mu;
+use Oberth::Common::Setup;
+
+use Env qw(@PATH @PKG_CONFIG_PATH $ARCHFLAGS);
+
+method _env() {
+	# Set up for OpenSSL (linking and utilities)
+	unshift @PKG_CONFIG_PATH, '/usr/local/opt/openssl/lib/pkgconfig';
+	unshift @PATH, '/usr/local/opt/openssl/bin';
+
+	# Set up for libffi linking
+	unshift @PKG_CONFIG_PATH, '/usr/local/opt/libffi/lib/pkgconfig';
+
+	# Add Homebrew gettext utilities to path
+	unshift @PATH, '/usr/local/opt/gettext/bin';
+
+	$ARCHFLAGS='-arch x86_64';
+}
+
+method _pre_run() {
+
+}
+
+method _install() {
+	say STDERR "Updating homebrew";
+	system(qw(brew update));
+
+	# Set up for X11 support
+	say STDERR "Installing xquartz homebrew cask for X11 support";
+	system(qw(brew tap Caskroom/cask));
+	system(qw(brew install Caskroom/cask/xquartz));
+
+	# Set up for pkg-config
+	system(qw(brew install pkg-config));
+
+	# Set up for OpenSSL (linking and utilities)
+	system(qw(brew install openssl));
+}
+
+method install_packages($repo) {
+	my @packages = @{ $repo->homebrew_get_packages };
+	say STDERR "Installing repo native deps";
+	if( @packages ) {
+		# Skip font cache generation (for fontconfig):
+		# <https://github.com/Homebrew/homebrew-core/pull/10947#issuecomment-285946088>
+		my $has_fontconfig_dep = eval {
+			system( qq{brew deps --union @packages | grep ^fontconfig\$ && brew install --force-bottle --build-bottle fontconfig} );
+		};
+
+		my @deps_to_install = grep {
+			my $dep = $_;
+			eval {
+				system( qq{brew ls @packages >/dev/null 2>&1} );
+			};
+			1 if $@;
+		} @packages;
+		say STDERR "Native deps to install: @deps_to_install";
+
+		if(@deps_to_install) {
+			system( qq{brew install @deps_to_install || true} );
+			system( qq{brew install @packages || true} );
+		}
+	}
+}
+
+1;

--- a/lib/Oberth/Prototype/System/MacOSHomebrew.pm
+++ b/lib/Oberth/Prototype/System/MacOSHomebrew.pm
@@ -4,6 +4,7 @@ package Oberth::Prototype::System::MacOSHomebrew;
 
 use Mu;
 use Oberth::Common::Setup;
+use IPC::System::Simple ();
 
 use Env qw(@PATH @PKG_CONFIG_PATH $ARCHFLAGS);
 
@@ -48,15 +49,17 @@ method install_packages($repo) {
 		# Skip font cache generation (for fontconfig):
 		# <https://github.com/Homebrew/homebrew-core/pull/10947#issuecomment-285946088>
 		my $has_fontconfig_dep = eval {
+			use autodie qw(:system);
 			system( qq{brew deps --union @packages | grep ^fontconfig\$ && brew install --force-bottle --build-bottle fontconfig} );
 		};
 
 		my @deps_to_install = grep {
 			my $dep = $_;
 			eval {
+				use autodie qw(:system);
 				system( qq{brew ls @packages >/dev/null 2>&1} );
 			};
-			1 if $@;
+			$@ ? 1 : 0;
 		} @packages;
 		say STDERR "Native deps to install: @deps_to_install";
 

--- a/maint/travis-ci/before-install
+++ b/maint/travis-ci/before-install
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+	./maint/build-docker
+	docker ps -a
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+	true
+fi

--- a/maint/travis-ci/before-install
+++ b/maint/travis-ci/before-install
@@ -4,5 +4,10 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 	./maint/build-docker
 	docker ps -a
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-	true
+	perl ./bin/oberthian bootstrap setup --dir extlib
+	perl ./bin/oberthian bootstrap generate-cpanfile --dir extlib
+	perl ./bin/oberthian bootstrap install-deps-from-cpanfile --dir extlib
+
+	git clone https://github.com/project-renard/curie.git
+	cd $TRAVIS_BUILD_DIR/curie && perl $TRAVIS_BUILD_DIR/bin/oberthian
 fi

--- a/maint/travis-ci/script
+++ b/maint/travis-ci/script
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+	docker run --rm -it oberth:latest sh -c 'cd /build/curie && perl /build/bin/oberthian test'
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+	true
+fi

--- a/maint/travis-ci/script
+++ b/maint/travis-ci/script
@@ -3,5 +3,5 @@
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 	docker run --rm -it oberth:latest sh -c 'cd /build/curie && perl /build/bin/oberthian test'
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-	true
+	cd $TRAVIS_BUILD_DIR/curie && perl $TRAVIS_BUILD_DIR/bin/oberthian test
 fi


### PR DESCRIPTION
- Tests on macOS via Travis CI osx build.
- Use non-SSL resolver for cpm for systems that do not have up-to-date SSL
  libraries.

Fixes <https://github.com/oberth-manoeuvre/oberth-prototype/issues/2>.
